### PR TITLE
Support Google Credential JSON Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,26 +11,25 @@
 
 ### Before you begin note that this package only supports using Service accounts to authenticate to the various Google Cloud Platform APIs using OAuth2.
 
-1.  Select or create a Cloud Platform project.
+1. Select or create a Cloud Platform project.
 
 [Go to the projects page][projects]
 
-2.  Enable billing for your project.
+2. Enable billing for your project.
 
 [Enable billing][billing]
 
-3.  Enable the Google Cloud Storage API.
+3. Enable the Google Cloud Storage API.
 
 [Enable the API][enable_api]
 
-4.  [Set up authentication with a service account][auth] so you can access the
+4. [Set up authentication with a service account][auth] so you can access the
 API from your local workstation.
 
 [projects]: https://console.cloud.google.com/project
 [billing]: https://support.google.com/cloud/answer/6293499#enable-billing
 [enable_api]: https://console.cloud.google.com/flows/enableapi?apiid=storage-api.googleapis.com
 [auth]: https://cloud.google.com/docs/authentication/getting-started
-
 
 ### To begin using GogleCloudProvider in your project you'll need to setup the initial configuration
 
@@ -43,9 +42,16 @@ In your `Package.swift` file, add the following
 And In `Configure.swift` or wherever you setup your configuration in Vapor
 
 ```swift
- let cloudConfig = GoogleCloudProviderConfig(projectId: "myprojectid-12345", rsaPrivateKey: "privatekey from your service account")
- services.register(cloudConfig) 
+ let cloudConfig = GoogleCloudProviderConfig(project: "myprojectid-12345", credentialFile: "path to your service account json")
+ services.register(cloudConfig)
  try services.register(GoogleCloudProvider())
+```
+
+Optionally, you can register an empty `GoogleCloudProviderConfig()` and configure the following environment variables:
+
+```shell
+export PROJECT_ID=myprojectid-12345
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/your/service-account.json
 ```
 
 ### Currently the following API's are implemented and you can follow the setup guides for each specific API to integrate with your Vapor project.

--- a/Sources/GoogleCloudProvider/Credentials/ApplicationDefault.swift
+++ b/Sources/GoogleCloudProvider/Credentials/ApplicationDefault.swift
@@ -17,7 +17,7 @@ import Foundation
 //        "type": "authorized_user"
 //    }
 
-struct ApplicationDefaultCredentials: Codable {
+struct GoogleApplicationDefaultCredentials: Codable {
     let clientId: String
     let clientSecret: String
     let refreshToken: String

--- a/Sources/GoogleCloudProvider/Credentials/ApplicationDefault.swift
+++ b/Sources/GoogleCloudProvider/Credentials/ApplicationDefault.swift
@@ -1,0 +1,32 @@
+//
+//  ApplicationDefault.swift
+//  Async
+//
+//  Created by Brian Hatfield on 7/17/18.
+//
+
+import Foundation
+
+// Loads credentials from ~/.config/gcloud/application_default_credentials.json
+//
+// Example JSON:
+//    {
+//        "client_id": "IDSTRING.apps.googleusercontent.com",
+//        "client_secret": "SECRETSTRING",
+//        "refresh_token": "REFRESHTOKEN",
+//        "type": "authorized_user"
+//    }
+
+struct ApplicationDefaultCredentials: Codable {
+    let clientId: String
+    let clientSecret: String
+    let refreshToken: String
+    let type: String
+
+    enum CodingKeys: String, CodingKey {
+        case clientId = "client_id"
+        case clientSecret = "client_secret"
+        case refreshToken = "refresh_token"
+        case type
+    }
+}

--- a/Sources/GoogleCloudProvider/Credentials/Loaders.swift
+++ b/Sources/GoogleCloudProvider/Credentials/Loaders.swift
@@ -12,10 +12,10 @@ enum CredentialLoadError: Error {
 }
 
 extension GoogleApplicationDefaultCredentials {
-    init(fromFile: String) throws {
+    init(contentsOfFile: String) throws {
         let decoder = JSONDecoder()
 
-        if let contents = try String(contentsOfFile: fromFile).data(using: .utf8) {
+        if let contents = try String(contentsOfFile: contentsOfFile).data(using: .utf8) {
             self = try decoder.decode(GoogleApplicationDefaultCredentials.self, from: contents)
         } else {
             throw CredentialLoadError.fileDecodeError
@@ -24,10 +24,10 @@ extension GoogleApplicationDefaultCredentials {
 }
 
 extension GoogleServiceAccountCredentials {
-    init(fromFile: String) throws {
+    init(contentsOfFile: String) throws {
         let decoder = JSONDecoder()
 
-        if let contents = try String(contentsOfFile: fromFile).data(using: .utf8) {
+        if let contents = try String(contentsOfFile: contentsOfFile).data(using: .utf8) {
             self = try decoder.decode(GoogleServiceAccountCredentials.self, from: contents)
         } else {
             throw CredentialLoadError.fileDecodeError

--- a/Sources/GoogleCloudProvider/Credentials/Loaders.swift
+++ b/Sources/GoogleCloudProvider/Credentials/Loaders.swift
@@ -1,0 +1,36 @@
+//
+//  Loaders.swift
+//  Async
+//
+//  Created by Brian Hatfield on 7/17/18.
+//
+
+import Foundation
+
+enum CredentialLoadError: Error {
+    case fileDecodeError
+}
+
+extension ApplicationDefaultCredentials {
+    init(fromFile: String) throws {
+        let decoder = JSONDecoder()
+
+        if let contents = try String(contentsOfFile: fromFile).data(using: .utf8) {
+            self = try decoder.decode(ApplicationDefaultCredentials.self, from: contents)
+        } else {
+            throw CredentialLoadError.fileDecodeError
+        }
+    }
+}
+
+extension ServiceAccountCredentials {
+    init(fromFile: String) throws {
+        let decoder = JSONDecoder()
+
+        if let contents = try String(contentsOfFile: fromFile).data(using: .utf8) {
+            self = try decoder.decode(ServiceAccountCredentials.self, from: contents)
+        } else {
+            throw CredentialLoadError.fileDecodeError
+        }
+    }
+}

--- a/Sources/GoogleCloudProvider/Credentials/Loaders.swift
+++ b/Sources/GoogleCloudProvider/Credentials/Loaders.swift
@@ -12,10 +12,11 @@ enum CredentialLoadError: Error {
 }
 
 extension GoogleApplicationDefaultCredentials {
-    init(contentsOfFile: String) throws {
+    init(contentsOfFile path: String) throws {
         let decoder = JSONDecoder()
+        let filePath = NSString(string: path).expandingTildeInPath
 
-        if let contents = try String(contentsOfFile: contentsOfFile).data(using: .utf8) {
+        if let contents = try String(contentsOfFile: filePath).data(using: .utf8) {
             self = try decoder.decode(GoogleApplicationDefaultCredentials.self, from: contents)
         } else {
             throw CredentialLoadError.fileDecodeError
@@ -24,10 +25,11 @@ extension GoogleApplicationDefaultCredentials {
 }
 
 extension GoogleServiceAccountCredentials {
-    init(contentsOfFile: String) throws {
+    init(contentsOfFile path: String) throws {
         let decoder = JSONDecoder()
+        let filePath = NSString(string: path).expandingTildeInPath
 
-        if let contents = try String(contentsOfFile: contentsOfFile).data(using: .utf8) {
+        if let contents = try String(contentsOfFile: filePath).data(using: .utf8) {
             self = try decoder.decode(GoogleServiceAccountCredentials.self, from: contents)
         } else {
             throw CredentialLoadError.fileDecodeError

--- a/Sources/GoogleCloudProvider/Credentials/Loaders.swift
+++ b/Sources/GoogleCloudProvider/Credentials/Loaders.swift
@@ -11,24 +11,24 @@ enum CredentialLoadError: Error {
     case fileDecodeError
 }
 
-extension ApplicationDefaultCredentials {
+extension GoogleApplicationDefaultCredentials {
     init(fromFile: String) throws {
         let decoder = JSONDecoder()
 
         if let contents = try String(contentsOfFile: fromFile).data(using: .utf8) {
-            self = try decoder.decode(ApplicationDefaultCredentials.self, from: contents)
+            self = try decoder.decode(GoogleApplicationDefaultCredentials.self, from: contents)
         } else {
             throw CredentialLoadError.fileDecodeError
         }
     }
 }
 
-extension ServiceAccountCredentials {
+extension GoogleServiceAccountCredentials {
     init(fromFile: String) throws {
         let decoder = JSONDecoder()
 
         if let contents = try String(contentsOfFile: fromFile).data(using: .utf8) {
-            self = try decoder.decode(ServiceAccountCredentials.self, from: contents)
+            self = try decoder.decode(GoogleServiceAccountCredentials.self, from: contents)
         } else {
             throw CredentialLoadError.fileDecodeError
         }

--- a/Sources/GoogleCloudProvider/Credentials/ServiceAccount.swift
+++ b/Sources/GoogleCloudProvider/Credentials/ServiceAccount.swift
@@ -24,7 +24,7 @@ import Foundation
 //        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/SERVICEACCOUNTNAME%40PROJECTID.iam.gserviceaccount.com"
 //    }
 
-struct ServiceAccountCredentials: Codable {
+struct GoogleServiceAccountCredentials: Codable {
     let type: String
     let projectId: String
     let privateKeyId: String

--- a/Sources/GoogleCloudProvider/Credentials/ServiceAccount.swift
+++ b/Sources/GoogleCloudProvider/Credentials/ServiceAccount.swift
@@ -1,0 +1,53 @@
+//
+//  ServiceAccount.swift
+//  Async
+//
+//  Created by Brian Hatfield on 7/17/18.
+//
+
+import Foundation
+
+// Loads credentials from a file specified in env:GOOGLE_APPLICATION_CREDENTIALS
+//
+// Example JSON:
+//
+//    {
+//        "type": "service_account",
+//        "project_id": "PROJECTID",
+//        "private_key_id": "PRIVATEKEYID",
+//        "private_key": "-----BEGIN PRIVATE KEY-----\nPEMPRIVATEKEY\n-----END PRIVATE KEY-----\n",
+//        "client_email": "SERVICEACCOUNTNAME@PROJECTID.iam.gserviceaccount.com",
+//        "client_id": "CLIENTID",
+//        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+//        "token_uri": "https://accounts.google.com/o/oauth2/token",
+//        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+//        "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/SERVICEACCOUNTNAME%40PROJECTID.iam.gserviceaccount.com"
+//    }
+
+struct ServiceAccountCredentials: Codable {
+    let type: String
+    let projectId: String
+    let privateKeyId: String
+    let privateKey: String
+    let clientEmail: String
+    let clientId: String
+
+    let authUri: URL
+    let tokenUri: URL
+    let authProviderX509CertUrl: URL
+    let clientX509CertUrl: URL
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case projectId = "project_id"
+        case privateKeyId = "private_key_id"
+        case privateKey = "private_key"
+        case clientEmail = "client_email"
+        case clientId = "client_id"
+        case authUri = "auth_uri"
+        case tokenUri = "token_uri"
+        case authProviderX509CertUrl = "auth_provider_x509_cert_url"
+        case clientX509CertUrl = "client_x509_cert_url"
+    }
+}
+

--- a/Sources/GoogleCloudProvider/OAuth/OAuthAccessToken.swift
+++ b/Sources/GoogleCloudProvider/OAuth/OAuthAccessToken.swift
@@ -7,13 +7,15 @@
 
 import Vapor
 
-public struct OAuthResponse: Content {
+public struct OAuthAccessToken: Content {
     var accessToken: String
+    var refreshToken: String?
     var tokenType: String
     var expiresIn: Int
     
     public enum CodingKeys: String, CodingKey {
         case accessToken = "access_token"
+        case refreshToken = "refresh_token"
         case tokenType = "token_type"
         case expiresIn = "expires_in"
     }

--- a/Sources/GoogleCloudProvider/OAuth/OAuthAccessToken.swift
+++ b/Sources/GoogleCloudProvider/OAuth/OAuthAccessToken.swift
@@ -9,13 +9,11 @@ import Vapor
 
 public struct OAuthAccessToken: Content {
     var accessToken: String
-    var refreshToken: String?
     var tokenType: String
     var expiresIn: Int
     
     public enum CodingKeys: String, CodingKey {
         case accessToken = "access_token"
-        case refreshToken = "refresh_token"
         case tokenType = "token_type"
         case expiresIn = "expires_in"
     }

--- a/Sources/GoogleCloudProvider/OAuth/OAuthApplicationDefault.swift
+++ b/Sources/GoogleCloudProvider/OAuth/OAuthApplicationDefault.swift
@@ -1,0 +1,43 @@
+//
+//  OAuthApplicationDefault.swift
+//  GoogleCloudProvider
+//
+//  Created by Brian Hatfield on 7/17/18.
+//
+
+import Vapor
+import Crypto
+import JWT
+
+public class OAuthApplicationDefault: OAuthRefreshable {
+    let client: Client
+    let credentials: GoogleApplicationDefaultCredentials
+
+    let audience: String = "https://www.googleapis.com/oauth2/v4/token"
+
+    init(credentials: GoogleApplicationDefaultCredentials, httpClient: Client) {
+        self.credentials = credentials
+        self.client = httpClient
+    }
+
+    // Google Documentation for this approach: https://developers.google.com/identity/protocols/OAuth2WebServer#offline
+    public func refresh() throws -> Future<OAuthAccessToken> {
+        let headers: HTTPHeaders = ["Content-Type": MediaType.urlEncodedForm.description]
+
+        let bodyParts = [
+            "client_id=\(credentials.clientId)",
+            "client_secret=\(credentials.clientSecret)",
+            "refresh_token=\(credentials.refreshToken)",
+            "grant_type=refresh_token",
+        ]
+
+        let body = bodyParts.joined(separator: "&")
+
+        return client.post(audience, headers: headers, beforeSend: { $0.http.body = HTTPBody(string: body) }).flatMap(to: OAuthAccessToken.self) { (response) in
+            if response.http.status == .ok {
+                return try JSONDecoder().decode(OAuthAccessToken.self, from: response.http, maxSize: 65_536, on: response)
+            }
+            throw Abort(.internalServerError)
+        }
+    }
+}

--- a/Sources/GoogleCloudProvider/OAuth/OAuthError.swift
+++ b/Sources/GoogleCloudProvider/OAuth/OAuthError.swift
@@ -5,8 +5,6 @@
 //  Created by Andrew Edwards on 4/16/18.
 //
 
-import Vapor
-
 enum OAuthError: Error {
     case unknownError
 }

--- a/Sources/GoogleCloudProvider/OAuth/OAuthPayload.swift
+++ b/Sources/GoogleCloudProvider/OAuth/OAuthPayload.swift
@@ -5,7 +5,6 @@
 //  Created by Andrew Edwards on 4/15/18.
 //
 
-import Vapor
 import JWT
 
 public struct OAuthPayload: JWTPayload {

--- a/Sources/GoogleCloudProvider/OAuth/OAuthRefreshable.swift
+++ b/Sources/GoogleCloudProvider/OAuth/OAuthRefreshable.swift
@@ -7,6 +7,10 @@
 
 import Vapor
 
+// Constants for OAuth URLs. PascalCase style from this suggestion: https://stackoverflow.com/a/31893982
+let GoogleOAuthTokenUrl = "https://www.googleapis.com/oauth2/v4/token"
+let GoogleOAuthTokenAudience = GoogleOAuthTokenUrl
+
 public protocol OAuthRefreshable {
     func isFresh(token: OAuthAccessToken, created: Date) -> Bool
     func refresh() throws -> Future<OAuthAccessToken>

--- a/Sources/GoogleCloudProvider/OAuth/OAuthRefreshable.swift
+++ b/Sources/GoogleCloudProvider/OAuth/OAuthRefreshable.swift
@@ -19,7 +19,7 @@ public protocol OAuthRefreshable {
 extension OAuthRefreshable {
     public func isFresh(token: OAuthAccessToken, created: Date) -> Bool {
         let now = Date()
-        let expiration = Date().addingTimeInterval(TimeInterval(token.expiresIn))
+        let expiration = created.addingTimeInterval(TimeInterval(token.expiresIn))
 
         return expiration > now
     }

--- a/Sources/GoogleCloudProvider/OAuth/OAuthRefreshable.swift
+++ b/Sources/GoogleCloudProvider/OAuth/OAuthRefreshable.swift
@@ -1,0 +1,22 @@
+//
+//  OAuthRefreshable.swift
+//  GoogleCloudProvider
+//
+//  Created by Brian Hatfield on 7/17/18.
+//
+
+import Vapor
+
+public protocol OAuthRefreshable {
+    func isFresh(token: OAuthAccessToken, created: Date) -> Bool
+    func refresh() throws -> Future<OAuthAccessToken>
+}
+
+extension OAuthRefreshable {
+    public func isFresh(token: OAuthAccessToken, created: Date) -> Bool {
+        let now = Date()
+        let expiration = Date().addingTimeInterval(TimeInterval(token.expiresIn))
+
+        return expiration > now
+    }
+}

--- a/Sources/GoogleCloudProvider/Provider.swift
+++ b/Sources/GoogleCloudProvider/Provider.swift
@@ -8,12 +8,12 @@
 import Vapor
 
 public struct GoogleCloudProviderConfig: Service {
-    public let project: String
-    public let privateKey: String
-    
-    public init(projectId: String, rsaPrivateKey: String) {
-        project = projectId
-        privateKey = rsaPrivateKey
+    let project: String
+    let serviceAccountCredentialPath: String?
+
+    public init(project: String, credentialFile: String? = nil) {
+        self.project = project
+        self.serviceAccountCredentialPath = credentialFile
     }
 }
 

--- a/Sources/GoogleCloudProvider/Provider.swift
+++ b/Sources/GoogleCloudProvider/Provider.swift
@@ -8,10 +8,10 @@
 import Vapor
 
 public struct GoogleCloudProviderConfig: Service {
-    let project: String
+    let project: String?
     let serviceAccountCredentialPath: String?
 
-    public init(project: String, credentialFile: String? = nil) {
+    public init(project: String?, credentialFile: String? = nil) {
         self.project = project
         self.serviceAccountCredentialPath = credentialFile
     }

--- a/Sources/GoogleCloudProvider/Storage/README.md
+++ b/Sources/GoogleCloudProvider/Storage/README.md
@@ -1,28 +1,18 @@
-#  Google Cloud Storage 
-
-## To get started with using Cloud Storage you'll want to setup the configuration.
-
-And In `Configure.swift` or wherever you setup your configuration in Vapor
-
-```swift
-let cloudStorageConfig = GoogleCloudStorageConfig(serviceAccountEmail: "my-service-account@my-project-id.iam.gserviceaccount.com", scope: [StorageScope.fullControl])
-services.register(cloudStorageConfig)
-```
-Notice the scope paramater takes in an array of desired scopes. They are static prperties on the `StorageScope` struct you can easily access or you cna provide the string literal value.
+# Google Cloud Storage
 
 ## Using the Storage API
 
 ### Creating a storage bucket
 
 ```swift
-
 func create(_ req: Request) throws -> Future<GoogleStorageBucket> {
     let cloudStorage = try req.make(GoogleCloudStorageClient.self)
 
     return try cloudStorage.buckets.create(name: "vapor-cloud-storage-demo")
 }
 ```
-```
+
+```json
 // Results in the following response
 {
     "updated": "2018-05-27T20:21:19Z",
@@ -42,7 +32,6 @@ func create(_ req: Request) throws -> Future<GoogleStorageBucket> {
 ### Uploading an object to cloud storage
 
 ```swift
-
 func upload(_ req: Request) throws -> Future<GoogleStorageObject> {
     let cloudStorage = try req.make(GoogleCloudStorageClient.self)
 
@@ -53,10 +42,11 @@ func upload(_ req: Request) throws -> Future<GoogleStorageObject> {
 }
 ```
 
-There are other API's available which are well [documented](https://cloud.google.com/storage/docs/json_api/v1/). 
-This is just a basic example of creating a bucket and uploading an object. 
+There are other API's available which are well [documented](https://cloud.google.com/storage/docs/json_api/v1/).
+This is just a basic example of creating a bucket and uploading an object.
 
 ### What's implemented
+
 * [x] BucketAccessControls
 * [x] Buckets
 * [x] Channels

--- a/Sources/GoogleCloudProvider/Storage/StorageClient.swift
+++ b/Sources/GoogleCloudProvider/Storage/StorageClient.swift
@@ -7,6 +7,10 @@
 
 import Vapor
 
+enum GoogleCloudStorageClientError: Error {
+    case projectIdMissing
+}
+
 public struct GoogleCloudStorageClient: ServiceType {
     public var bucketAccessControl: GoogleBucketAccessControlAPI
     public var buckets: GoogleStorageBucketAPI
@@ -17,26 +21,52 @@ public struct GoogleCloudStorageClient: ServiceType {
     public var object: GoogleStorageObjectAPI
     
     init(providerconfig: GoogleCloudProviderConfig, client: Client) throws {
+        let env = ProcessInfo.processInfo.environment
+
+        // A token implementing OAuthRefreshable. Set via the priority order below.
         let refreshableToken: OAuthRefreshable
 
-        // Locate the ceredentials to use for this client. In order of priority:
+        // An optional configuredProjectId, available in OAuthServiceAccounts only. Set
+        // by the same token priority order below.
+        var configuredProjectId: String?
+
+        // Locate the credentials to use for this client. In order of priority:
         // - Environment Variable Specified Credentials (GOOGLE_APPLICATION_CREDENTIALS)
-        // - GoogleCloudProviderConfig's serviceAccountCredentialPath (optionally configured)
+        // - GoogleCloudProviderConfig's .serviceAccountCredentialPath (optionally configured)
         // - Application Default Credentials, located in the constant
-        if let credentialPath = ProcessInfo.processInfo.environment["GOOGLE_APPLICATION_CREDENTIALS"] {
+        if let credentialPath = env["GOOGLE_APPLICATION_CREDENTIALS"] {
             let credentials = try GoogleServiceAccountCredentials(contentsOfFile: credentialPath)
 
+            configuredProjectId = credentials.projectId
             refreshableToken = OAuthServiceAccount(credentials: credentials, scopes: [StorageScope.fullControl], httpClient: client)
         } else if let credentialPath = providerconfig.serviceAccountCredentialPath {
             let credentials = try GoogleServiceAccountCredentials(contentsOfFile: credentialPath)
 
+            configuredProjectId = credentials.projectId
             refreshableToken = OAuthServiceAccount(credentials: credentials, scopes: [StorageScope.fullControl], httpClient: client)
         } else {
             let credentials = try GoogleApplicationDefaultCredentials(contentsOfFile: "~/.config/gcloud/application_default_credentials.json")
             refreshableToken = OAuthApplicationDefault(credentials: credentials, httpClient: client)
         }
-        
-        let storageRequest = GoogleCloudStorageRequest(httpClient: client, oauth: refreshableToken, project: providerconfig.project)
+
+        // projectId set by the below priority ordering.
+        let projectId: String
+
+        // Set the projectId to use for this client. In order of priority:
+        // - Environment Variable (PROJECT_ID)
+        // - GoogleCloudProviderConfig's .project (optionally configured)
+        // - The project ID from a service account's credentials file (only available in service account credentials)
+        if let project = env["PROJECT_ID"] {
+            projectId = project
+        } else if let project = providerconfig.project {
+            projectId = project
+        } else if let project = configuredProjectId {
+            projectId = project
+        } else {
+            throw GoogleCloudStorageClientError.projectIdMissing
+        }
+
+        let storageRequest = GoogleCloudStorageRequest(httpClient: client, oauth: refreshableToken, project: projectId)
         
         bucketAccessControl = GoogleBucketAccessControlAPI(request: storageRequest)
         buckets = GoogleStorageBucketAPI(request: storageRequest)

--- a/Sources/GoogleCloudProvider/Storage/StorageClient.swift
+++ b/Sources/GoogleCloudProvider/Storage/StorageClient.swift
@@ -32,8 +32,7 @@ public struct GoogleCloudStorageClient: ServiceType {
 
             refreshableToken = OAuthServiceAccount(credentials: credentials, scopes: [StorageScope.fullControl], httpClient: client)
         } else {
-            let adcPath = NSString(string: "~/.config/gcloud/application_default_credentials.json").expandingTildeInPath
-            let credentials = try GoogleApplicationDefaultCredentials(contentsOfFile: adcPath)
+            let credentials = try GoogleApplicationDefaultCredentials(contentsOfFile: "~/.config/gcloud/application_default_credentials.json")
             refreshableToken = OAuthApplicationDefault(credentials: credentials, httpClient: client)
         }
         

--- a/Sources/GoogleCloudProvider/Storage/StorageClient.swift
+++ b/Sources/GoogleCloudProvider/Storage/StorageClient.swift
@@ -17,7 +17,7 @@ public struct GoogleCloudStorageClient: ServiceType {
     public var object: GoogleStorageObjectAPI
     
     init(providerconfig: GoogleCloudProviderConfig, storageconfig: GoogleCloudStorageConfig, client: Client) {
-        let oauthRequester = GoogleOAuth(serviceEmail: storageconfig.email, scopes: storageconfig.scope, privateKey: providerconfig.privateKey, httpClient: client)
+        let oauthRequester = GoogleServiceAccountOAuth(serviceEmail: storageconfig.email, scopes: storageconfig.scope, privateKey: providerconfig.privateKey, httpClient: client)
         let storageRequest = GoogleCloudStorageRequest(httpClient: client, oauth: oauthRequester, project: providerconfig.project)
         
         bucketAccessControl = GoogleBucketAccessControlAPI(request: storageRequest)

--- a/Sources/GoogleCloudProvider/Storage/StorageConfig.swift
+++ b/Sources/GoogleCloudProvider/Storage/StorageConfig.swift
@@ -8,11 +8,9 @@
 import Vapor
 
 public struct GoogleCloudStorageConfig: Service {
-    public let email: String
     public let scope: [String]
     
-    public init(serviceAccountEmail: String, scope: [String]) {
-        email = serviceAccountEmail
+    public init(scope: [String]) {
         self.scope = scope
     }
 }

--- a/Sources/GoogleCloudProvider/Storage/StorageRequest.swift
+++ b/Sources/GoogleCloudProvider/Storage/StorageRequest.swift
@@ -17,13 +17,13 @@ extension HTTPHeaders {
 
 
 public class GoogleCloudStorageRequest {
-    var authtoken: OAuthResponse?
+    var authtoken: OAuthAccessToken?
     var tokenCreatedTime: Date?
-    let oauthRequester: GoogleOAuth
+    let oauthRequester: GoogleServiceAccountOAuth
     let project: String
     let httpClient: Client
     
-    init(httpClient: Client, oauth: GoogleOAuth, project: String) {
+    init(httpClient: Client, oauth: GoogleServiceAccountOAuth, project: String) {
         oauthRequester = oauth
         self.httpClient = httpClient
         self.project = project

--- a/Tests/GoogleCloudProviderTests/CredentialTests.swift
+++ b/Tests/GoogleCloudProviderTests/CredentialTests.swift
@@ -1,0 +1,38 @@
+//
+//  CredentialTests.swift
+//  Async
+//
+//  Created by Brian Hatfield on 7/17/18.
+//
+
+import Foundation
+import XCTest
+
+@testable import GoogleCloudProvider
+
+final class CredentialTests: XCTestCase {
+    func testLoadApplicationDefaultCredentials() throws {
+        let expandedPath = NSString(string: "~/.config/gcloud/application_default_credentials.json").expandingTildeInPath
+
+        XCTAssertNoThrow(try ApplicationDefaultCredentials(fromFile: expandedPath))
+
+        let creds = try ApplicationDefaultCredentials(fromFile: expandedPath)
+
+        XCTAssert(creds.type == "authorized_user")
+    }
+
+    func testLoadServiceAccountCredentials() throws {
+        let expandedPath = NSString(string: "~/Documents/misc/test-service-account.json").expandingTildeInPath
+
+        XCTAssertNoThrow(try ServiceAccountCredentials(fromFile: expandedPath))
+
+        let creds = try ServiceAccountCredentials(fromFile: expandedPath)
+
+        XCTAssert(creds.type == "service_account")
+    }
+
+    static var allTests = [
+        ("testLoadApplicationDefaultCredentials", testLoadApplicationDefaultCredentials),
+        ("testLoadServiceAccount", testLoadServiceAccountCredentials)
+    ]
+}

--- a/Tests/GoogleCloudProviderTests/CredentialTests.swift
+++ b/Tests/GoogleCloudProviderTests/CredentialTests.swift
@@ -11,23 +11,34 @@ import XCTest
 @testable import GoogleCloudProvider
 
 final class CredentialTests: XCTestCase {
+    var checkoutPath: String {
+        if let path = ProcessInfo.processInfo.environment["PROJECT_PATH"] {
+            return path
+        }
+
+        XCTFail("PROJECT_PATH environment variable not set; cannot load fixtures")
+        return ""
+    }
+
     func testLoadApplicationDefaultCredentials() throws {
-        let expandedPath = NSString(string: "~/.config/gcloud/application_default_credentials.json").expandingTildeInPath
+        let credentialFile = checkoutPath + "/Tests/GoogleCloudProviderTests/Fixtures/ADC.json"
 
-        XCTAssertNoThrow(try ApplicationDefaultCredentials(contentsOfFile: expandedPath))
+        XCTAssertNoThrow(try GoogleApplicationDefaultCredentials(contentsOfFile: credentialFile))
 
-        let creds = try ApplicationDefaultCredentials(contentsOfFile: expandedPath)
+        let creds = try GoogleApplicationDefaultCredentials(contentsOfFile: credentialFile)
 
+        XCTAssert(creds.clientId == "IDSTRING.apps.googleusercontent.com")
         XCTAssert(creds.type == "authorized_user")
     }
 
     func testLoadServiceAccountCredentials() throws {
-        let expandedPath = NSString(string: "~/Documents/misc/test-service-account.json").expandingTildeInPath
+        let credentialFile = checkoutPath + "/Tests/GoogleCloudProviderTests/Fixtures/ServiceAccount.json"
 
-        XCTAssertNoThrow(try ServiceAccountCredentials(contentsOfFile: expandedPath))
+        XCTAssertNoThrow(try GoogleServiceAccountCredentials(contentsOfFile: credentialFile))
 
-        let creds = try ServiceAccountCredentials(contentsOfFile: expandedPath)
+        let creds = try GoogleServiceAccountCredentials(contentsOfFile: credentialFile)
 
+        XCTAssert(creds.clientId == "CLIENTID")
         XCTAssert(creds.type == "service_account")
     }
 

--- a/Tests/GoogleCloudProviderTests/CredentialTests.swift
+++ b/Tests/GoogleCloudProviderTests/CredentialTests.swift
@@ -14,9 +14,9 @@ final class CredentialTests: XCTestCase {
     func testLoadApplicationDefaultCredentials() throws {
         let expandedPath = NSString(string: "~/.config/gcloud/application_default_credentials.json").expandingTildeInPath
 
-        XCTAssertNoThrow(try ApplicationDefaultCredentials(fromFile: expandedPath))
+        XCTAssertNoThrow(try ApplicationDefaultCredentials(contentsOfFile: expandedPath))
 
-        let creds = try ApplicationDefaultCredentials(fromFile: expandedPath)
+        let creds = try ApplicationDefaultCredentials(contentsOfFile: expandedPath)
 
         XCTAssert(creds.type == "authorized_user")
     }
@@ -24,9 +24,9 @@ final class CredentialTests: XCTestCase {
     func testLoadServiceAccountCredentials() throws {
         let expandedPath = NSString(string: "~/Documents/misc/test-service-account.json").expandingTildeInPath
 
-        XCTAssertNoThrow(try ServiceAccountCredentials(fromFile: expandedPath))
+        XCTAssertNoThrow(try ServiceAccountCredentials(contentsOfFile: expandedPath))
 
-        let creds = try ServiceAccountCredentials(fromFile: expandedPath)
+        let creds = try ServiceAccountCredentials(contentsOfFile: expandedPath)
 
         XCTAssert(creds.type == "service_account")
     }

--- a/Tests/GoogleCloudProviderTests/Fixtures/ADC.json
+++ b/Tests/GoogleCloudProviderTests/Fixtures/ADC.json
@@ -1,0 +1,6 @@
+{
+    "client_id": "IDSTRING.apps.googleusercontent.com",
+    "client_secret": "SECRETSTRING",
+    "refresh_token": "REFRESHTOKEN",
+    "type": "authorized_user"
+}

--- a/Tests/GoogleCloudProviderTests/Fixtures/ServiceAccount.json
+++ b/Tests/GoogleCloudProviderTests/Fixtures/ServiceAccount.json
@@ -1,0 +1,12 @@
+{
+    "type": "service_account",
+    "project_id": "PROJECTID",
+    "private_key_id": "PRIVATEKEYID",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nPEMPRIVATEKEY\n-----END PRIVATE KEY-----\n",
+    "client_email": "SERVICEACCOUNTNAME@PROJECTID.iam.gserviceaccount.com",
+    "client_id": "CLIENTID",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://accounts.google.com/o/oauth2/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/SERVICEACCOUNTNAME%40PROJECTID.iam.gserviceaccount.com"
+}

--- a/Tests/GoogleCloudProviderTests/StorageTests.swift
+++ b/Tests/GoogleCloudProviderTests/StorageTests.swift
@@ -1,0 +1,90 @@
+//
+//  StorageTests.swift
+//  GoogleCloudProvider
+//
+//  Created by Brian Hatfield on 7/18/18.
+//
+
+import Foundation
+import XCTest
+
+import Vapor
+
+@testable import GoogleCloudProvider
+
+final class StorageTests: XCTestCase {
+    var GCSProject: String?
+    var CredentialFile: String?
+
+    override func setUp() {
+        super.setUp()
+
+        let env = ProcessInfo.processInfo.environment
+
+        // Because these tests actually hit Google Cloud Storage, you must configure your scheme to include
+        // the following environment variables:
+        // - STORAGE_TEST_PROJECT: your google cloud project name
+        // - STORAGE_TEST_SERVICEACCOUNT: a path to a service account JSON file
+
+        guard let project = env["STORAGE_TEST_PROJECT"] else {
+            XCTFail("GCS project environment variable 'STORAGE_TEST_PROJECT' not configured")
+            return
+        }
+
+        GCSProject = project
+
+        guard let credentialFile = env["STORAGE_TEST_SERVICEACCOUNT"] else {
+            XCTFail("GCS credentials environment variable 'STORAGE_TEST_SERVICEACCOUNT' not configured")
+            return
+        }
+
+        CredentialFile = credentialFile
+    }
+
+    func testWithApplicationDefaultCredentials() throws {
+        let app = try Application()
+        let req = Request(using: app)
+        let client = try req.client()
+
+        let providerConfig = GoogleCloudProviderConfig(project: GCSProject!)
+
+        let storageClient = try GoogleCloudStorageClient(providerconfig: providerConfig, client: client)
+
+        try storageClient.buckets.list().map({ buckets in
+            guard let bucketList = buckets.items else {
+                XCTFail("Buckets optional is nil")
+                return
+            }
+
+            XCTAssert(bucketList.count > 0)
+        }).catch({ err in
+            XCTFail(err.localizedDescription)
+        }).wait()
+    }
+
+    func testWithServiceAccountCredentials() throws {
+        let app = try Application()
+        let req = Request(using: app)
+        let client = try req.client()
+
+        let providerConfig = GoogleCloudProviderConfig(project: GCSProject!, credentialFile: CredentialFile!)
+
+        let storageClient = try GoogleCloudStorageClient(providerconfig: providerConfig, client: client)
+
+        try storageClient.buckets.list().map({ buckets in
+            guard let bucketList = buckets.items else {
+                XCTFail("Buckets optional is nil")
+                return
+            }
+
+            XCTAssert(bucketList.count > 0)
+        }).catch({ err in
+            XCTFail(err.localizedDescription)
+        }).wait()
+    }
+
+    static var allTests = [
+        ("testWithApplicationDefaultCredentials", testWithApplicationDefaultCredentials),
+        ("testWithServiceAccountCredentials", testWithServiceAccountCredentials)
+    ]
+}

--- a/Tests/GoogleCloudProviderTests/XCTestManifests.swift
+++ b/Tests/GoogleCloudProviderTests/XCTestManifests.swift
@@ -4,6 +4,7 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(GoogleCloudProviderTests.allTests),
+        testCase(CredentialTests.allTests),
     ]
 }
 #endif


### PR DESCRIPTION
This PR is against our own repo for internal feedback, then I will create a PR against the base repo.

This PR adds support for application_default_credentials and service account credentials.

It then dynamically chooses which credential file to use (depending on if one was provided in the configuration) and provides that to StorageRequest.

I also improved the naming of some types and methods to make their behavior clear.